### PR TITLE
Fix range generation bug in bos-algo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub fn generate_distribution(
 
         let feasible_max: u32 = u32::try_from(feasible_max_u128).unwrap_or(MAX_F);
 
-        let val = rng.random_range(MIN_F..=feasible_max);
+        let val = rng.gen_range(MIN_F..=feasible_max);
 
         dist.push(Bottle {
             tier: Tier::F,


### PR DESCRIPTION
## Summary
- fix call to `Rng::gen_range`

## Testing
- `cargo test`
- `cargo clippy`
